### PR TITLE
Fix turn, checking winner, game ending

### DIFF
--- a/Gui/game_screen.py
+++ b/Gui/game_screen.py
@@ -322,7 +322,7 @@ class game_screen():
         # winner
         winner_text_string = ""
         if self.is_end:
-            if self.turn == "cpu":
+            if self.turn == "player":
                 winner_text_string = "Komputer zwyciężył"
             else:
                 winner_text_string = "Wygrałeś"
@@ -460,7 +460,7 @@ class game_screen():
         if not any("S" in s for s in self.game_board_1):
             self.is_end = True
 
-        elif not any("S" in s for s in self.game_board_2):
+        elif not any("S" in s for s in self.game_board_2) and not any("Sh" in s for s in self.game_board_2):
             self.is_end = True
 
         else:

--- a/Statki.py
+++ b/Statki.py
@@ -174,7 +174,7 @@ while run:
                     if game.turn == "player":
                         for a, row in enumerate(game.board_rect_AI):
                             for b, rect in enumerate(row):
-                                if rect.collidepoint(pygame.mouse.get_pos()):
+                                if rect.collidepoint(pygame.mouse.get_pos()) and game.is_end is False:
                                     game.player_shoot(a,b)
             for a, row in enumerate(game.board_rect_AI):
                 for b, rect in enumerate(row):


### PR DESCRIPTION
Now the player can't move after the bot wins, the game-ending condition is correct (after added the hover effect), and the winner is correct.